### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,5 @@ FROM node:onbuild
 
 RUN \
   sed -i 's/127.0.0.1/redis/' config.json
+
+ENTRYPOINT [ "node", "generator.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:onbuild
+
+RUN \
+  sed -i 's/127.0.0.1/redis/' config.json

--- a/generator.js
+++ b/generator.js
@@ -97,11 +97,11 @@ Generator.prototype._checkParams = function( p ) {
     process.exit();
   }
 
-  if( p.length < 2 || p.length > 2 ) {
-    process.stdout.write('please pass <type> <qty> as command line parameters\ne.g. node generator.js string 100\n');
+  if( p.length < 2 || p.length > 3 ) {
+    process.stdout.write('please pass <type> <qty> <key_prefix> as command line parameters\ne.g. node generator.js string 100\n');
     return false;
   }
-  else if( p.length === 2) {
+  else if( p.length === 2 || p.length === 3 ) {
     //check to see what we have (in whatever order - check for isNaN)
     if((typeof +p[0] === 'number' && +p[0] === +p[0] ) && typeof p[1] === 'string' ) {
       this.qty = +p[0];
@@ -112,7 +112,7 @@ Generator.prototype._checkParams = function( p ) {
       this.createType = p[0];
     }
     else {
-      process.stdout.write('please pass <type> <qty> as command line parameters\ne.g. node generator.js string 100\n');
+      process.stdout.write('please pass <type> <qty> <key_prefix> as command line parameters\ne.g. node generator.js string 100\n');
       return false;
     }
 
@@ -128,13 +128,19 @@ Generator.prototype._checkParams = function( p ) {
 
     this.type = type[this.createType];
     this.limit = this.qty;
+    if ( typeof p[2] === "undefined" ) {
+      this.prefix = '';
+    }
+    else {
+      this.prefix = p[2] + ':';
+    }
     return true;
   }
   return false;
 }
 
 Generator.prototype._getKey = function(){
-  return uuid.v4(); 
+  return this.prefix + uuid.v4();
 };
 
 Generator.prototype._getValue = function(){
@@ -202,5 +208,3 @@ generator.pipe(rStream.redis);
 generator.on('end', function(err){
   rStream.end();
 });
-
-


### PR DESCRIPTION
Add Dockerfile to enable image building. Using the official nodejs image. More info at https://hub.docker.com/_/node/
Allowed me to work on this software without any NodeJS setup on my Linux dev box.

Since it's not possible to specify the target Redis server other than config file (eg, command-line or env var), I've resorted to replace ```127.0.0.1``` by ```redis``` as the default Redis server in the included config file for the image, since neither ```localhost``` nor ```127.0.0.1``` would work from inside a container.

As of now, you can either:
* Link yourself the Docker container to an existing Redis instance via ```--link``` or ```--add-host``` at container launch (linked hostname should be ```redis```)
* Mount an existing ```config.json``` file from the Docker host via ```-v``` option
(Using linked container as demo method below)

Build:

```
$ docker build -t redis-random-data-generator .
```

Run a Redis server to use it later for testing (exposing Redis port ```-p``` is not required):

```
$ docker run --rm -it --name redis [ -p 6379:6379 ] redis:3 redis-server --save "" --maxmemory 1gb
```

From another terminal, launch a container from the above built image:

```
docker run --rm -it --link redis:redis redis-random-data-generator [ options... ]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it --link redis:redis pataquets/redis-random-data-generator [ options... ]
```

Notice I'm using the `--rm` (remove container on finish) and interactive mode (`-it`) Docker launch flags. Stop containers by `CTRL+C`'ing them.

Optional improvement to come:
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process.